### PR TITLE
Update to 3.32.1

### DIFF
--- a/appdata-add-releases.patch
+++ b/appdata-add-releases.patch
@@ -1,0 +1,29 @@
+From 3a11f67750cb5da6ce687fb6e460a8cab223acdf Mon Sep 17 00:00:00 2001
+From: Will Thompson <will@willthompson.co.uk>
+Date: Wed, 14 Aug 2019 12:11:20 +0100
+Subject: [PATCH 2/2] appdata: add <releases>
+
+This is the last stable release. (<releases> is now mandatory on
+Flathub.)
+
+This should be updated for each new release, ideally with a
+<description> containing release notes.
+---
+ data/org.gnome.Characters.appdata.xml.in | 3 +++
+ 1 file changed, 3 insertions(+)
+
+diff --git a/data/org.gnome.Characters.appdata.xml.in b/data/org.gnome.Characters.appdata.xml.in
+index 19486e0..5a88c45 100644
+--- a/data/org.gnome.Characters.appdata.xml.in
++++ b/data/org.gnome.Characters.appdata.xml.in
+@@ -33,4 +33,7 @@
+   </kudos>
+   <translation type="gettext">org.gnome.Characters</translation>
+   <content_rating type="oars-1.1"/>
++  <releases>
++    <release version="3.32.1" date="2019-04-08"/>
++  </releases>
+ </component>
+-- 
+2.20.1
+

--- a/appdata-simplify-OARS-data.patch
+++ b/appdata-simplify-OARS-data.patch
@@ -1,0 +1,52 @@
+From 5b9d53d984733c60ac8071abe9d261b82db62937 Mon Sep 17 00:00:00 2001
+From: Will Thompson <will@willthompson.co.uk>
+Date: Wed, 14 Aug 2019 12:10:56 +0100
+Subject: [PATCH 1/2] appdata: simplify OARS data
+
+If the value is 'none', the category can be omitted.
+---
+ data/org.gnome.Characters.appdata.xml.in | 30 +-----------------------
+ 1 file changed, 1 insertion(+), 29 deletions(-)
+
+diff --git a/data/org.gnome.Characters.appdata.xml.in b/data/org.gnome.Characters.appdata.xml.in
+index 1ff0e6a..19486e0 100644
+--- a/data/org.gnome.Characters.appdata.xml.in
++++ b/data/org.gnome.Characters.appdata.xml.in
+@@ -32,33 +32,5 @@
+     <kudo>SearchProvider</kudo>
+   </kudos>
+   <translation type="gettext">org.gnome.Characters</translation>
+-  <content_rating type="oars-1.1">
+-    <content_attribute id="violence-cartoon">none</content_attribute>
+-    <content_attribute id="violence-fantasy">none</content_attribute>
+-    <content_attribute id="violence-realistic">none</content_attribute>
+-    <content_attribute id="violence-bloodshed">none</content_attribute>
+-    <content_attribute id="violence-sexual">none</content_attribute>
+-    <content_attribute id="violence-desecration">none</content_attribute>
+-    <content_attribute id="violence-slavery">none</content_attribute>
+-    <content_attribute id="violence-worship">none</content_attribute>
+-    <content_attribute id="drugs-alcohol">none</content_attribute>
+-    <content_attribute id="drugs-narcotics">none</content_attribute>
+-    <content_attribute id="drugs-tobacco">none</content_attribute>
+-    <content_attribute id="sex-nudity">none</content_attribute>
+-    <content_attribute id="sex-themes">none</content_attribute>
+-    <content_attribute id="sex-homosexuality">none</content_attribute>
+-    <content_attribute id="sex-prostitution">none</content_attribute>
+-    <content_attribute id="sex-adultery">none</content_attribute>
+-    <content_attribute id="sex-appearance">none</content_attribute>
+-    <content_attribute id="language-profanity">none</content_attribute>
+-    <content_attribute id="language-humor">none</content_attribute>
+-    <content_attribute id="language-discrimination">none</content_attribute>
+-    <content_attribute id="social-chat">none</content_attribute>
+-    <content_attribute id="social-info">none</content_attribute>
+-    <content_attribute id="social-audio">none</content_attribute>
+-    <content_attribute id="social-location">none</content_attribute>
+-    <content_attribute id="social-contacts">none</content_attribute>
+-    <content_attribute id="money-purchasing">none</content_attribute>
+-    <content_attribute id="money-gambling">none</content_attribute>
+-  </content_rating>
++  <content_rating type="oars-1.1"/>
+ </component>
+-- 
+2.20.1
+

--- a/org.gnome.Characters.json
+++ b/org.gnome.Characters.json
@@ -27,26 +27,30 @@
     ],
     "modules": [
         {
-            "name": "gnome-desktop",
-            "config-opts": ["--disable-debug-tools", "--disable-udev"],
-            "sources": [
+            "name" : "gnome-desktop",
+            "buildsystem" : "meson",
+            "config-opts" : [
+                "-Ddebug-tools=false",
+                "-Dudev=disabled"
+            ],
+            "sources" : [
                 {
-                    "type": "archive",
-                    "url": "https://download.gnome.org/sources/gnome-desktop/3.28/gnome-desktop-3.28.2.tar.xz",
-                    "sha256": "605087bff17c61bc167ccb5a61ed4d06eab922fcce384576ed2a3577214c8330"
+                    "type" : "archive",
+                    "url" : "https://download.gnome.org/sources/gnome-desktop/3.32/gnome-desktop-3.32.2.tar.xz",
+                    "sha256" : "099f71b29310c999c28f2bf272c846bbd7efc8c6c438b37d15f374230ce92d2e"
                 }
             ]
         },
         {
-            "name": "libunistring",
-            "cleanup": [
+            "name" : "libunistring",
+            "cleanup" : [
                 "/share"
             ],
-            "sources": [
+            "sources" : [
                 {
-                    "type": "archive",
-                    "url": "https://ftp.gnu.org/gnu/libunistring/libunistring-0.9.10.tar.xz",
-                    "sha256": "eb8fb2c3e4b6e2d336608377050892b54c3c983b646c561836550863003c05d7"
+                    "type" : "archive",
+                    "url" : "https://ftp.gnu.org/gnu/libunistring/libunistring-0.9.10.tar.xz",
+                    "sha256" : "eb8fb2c3e4b6e2d336608377050892b54c3c983b646c561836550863003c05d7"
                 }
             ]
         },

--- a/org.gnome.Characters.json
+++ b/org.gnome.Characters.json
@@ -1,29 +1,38 @@
 {
-    "app-id": "org.gnome.Characters",
-    "runtime": "org.gnome.Platform",
-    "runtime-version": "3.32",
-    "branch": "stable",
-    "sdk": "org.gnome.Sdk",
-    "finish-args": [
-        /* X11 + XShm access */
-        "--share=ipc", "--socket=x11",
-        /* Wayland access */
+    "app-id" : "org.gnome.Characters",
+    "runtime" : "org.gnome.Platform",
+    "runtime-version" : "3.32",
+    "command" : "gnome-characters",
+    "sdk" : "org.gnome.Sdk",
+    "finish-args" : [
+        "--share=ipc",
+        "--socket=x11",
         "--socket=wayland",
-        /* Needed for dconf to work */
-        "--filesystem=xdg-run/dconf", "--filesystem=~/.config/dconf:ro",
-        "--talk-name=ca.desrt.dconf", "--env=DCONF_USER_CONFIG_DIR=.config/dconf"
+        "--filesystem=xdg-run/dconf",
+        "--filesystem=~/.config/dconf:ro",
+        "--talk-name=ca.desrt.dconf",
+        "--env=DCONF_USER_CONFIG_DIR=.config/dconf"
     ],
     "build-options" : {
-        "cflags": "-O2 -g",
-        "cxxflags": "-O2 -g"
+        "cflags" : "-O2 -g",
+        "cxxflags" : "-O2 -g",
+        "env" : {
+        }
     },
-    "cleanup": ["/include", "/lib/pkgconfig",
-                "/share/pkgconfig", "/share/aclocal",
-                "/man", "/share/man", "/share/gtk-doc",
-                "*.la", "*.a",
-                "/share/doc", "/share/gir-1.0"
+    "cleanup" : [
+        "/include",
+        "/lib/pkgconfig",
+        "/share/pkgconfig",
+        "/share/aclocal",
+        "/man",
+        "/share/man",
+        "/share/gtk-doc",
+        "*.la",
+        "*.a",
+        "/share/doc",
+        "/share/gir-1.0"
     ],
-    "modules": [
+    "modules" : [
         {
             "name" : "gnome-desktop",
             "buildsystem" : "meson",

--- a/org.gnome.Characters.json
+++ b/org.gnome.Characters.json
@@ -1,11 +1,9 @@
 {
     "app-id": "org.gnome.Characters",
     "runtime": "org.gnome.Platform",
-    "runtime-version": "3.28",
+    "runtime-version": "3.32",
     "branch": "stable",
     "sdk": "org.gnome.Sdk",
-    "copy-icon": true,
-    "rename-icon": "gnome-characters",
     "finish-args": [
         /* X11 + XShm access */
         "--share=ipc", "--socket=x11",
@@ -55,14 +53,18 @@
             ]
         },
         {
-            "name": "gnome-characters",
-            "buildsystem": "meson",
-            "config-opts": ["-Ddbus_service_dir=/app/share/dbus-1/services/"],
-            "sources": [
+            "name" : "gnome-characters",
+            "buildsystem" : "meson",
+            "builddir" : true,
+            "config-opts" : [
+                "--buildtype",
+                "release"
+            ],
+            "sources" : [
                 {
-                    "type": "archive",
-                    "url": "https://download.gnome.org/sources/gnome-characters/3.28/gnome-characters-3.28.2.tar.xz",
-                    "sha256": "8016f974f4fcdd207f1a3784b2e82c66ebe62451ced0d03fd3bc181e87b0d512"
+                    "type" : "archive",
+                    "url" : "https://download.gnome.org/sources/gnome-characters/3.32/gnome-characters-3.32.1.tar.xz",
+                    "sha256" : "5a9225ad527f9e185d3f1beb84e358a6571578aaeb75f47c4e07cdd48b08efd6"
                 }
             ]
         }

--- a/org.gnome.Characters.json
+++ b/org.gnome.Characters.json
@@ -74,6 +74,13 @@
                     "type" : "archive",
                     "url" : "https://download.gnome.org/sources/gnome-characters/3.32/gnome-characters-3.32.1.tar.xz",
                     "sha256" : "5a9225ad527f9e185d3f1beb84e358a6571578aaeb75f47c4e07cdd48b08efd6"
+                },
+                {
+                    "type": "patch",
+                    "paths": [
+                        "appdata-simplify-OARS-data.patch",
+                        "appdata-add-releases.patch"
+                    ]
                 }
             ]
         }


### PR DESCRIPTION
Implicitly addresses https://github.com/flathub/flathub/issues/1081 since OARS data was added upstream some time ago by @nedrichards. Also addresses https://github.com/flathub/flathub/issues/667 by using the 3.32 runtime.

Fixes #6. Fixes #5. New patches [sent upstream as !38](https://gitlab.gnome.org/GNOME/gnome-characters/merge_requests/38).