### PR TITLE
Bump to 3.34

### DIFF
--- a/org.gnome.Characters.json
+++ b/org.gnome.Characters.json
@@ -7,7 +7,8 @@
     "finish-args" : [
         "--share=ipc",
         "--socket=x11",
-        "--socket=wayland"
+        "--socket=wayland",
+        "--metadata=X-DConf=migrate-path=/org/gnome/Characters/"
     ],
     "cleanup" : [
         "/include",


### PR DESCRIPTION
This also removes dconf access as it's not required anymore.