### PR TITLE
Drop ineffective cleanup commands

### DIFF
--- a/org.gnome.Characters.json
+++ b/org.gnome.Characters.json
@@ -14,14 +14,6 @@
     "cleanup": [
         "/include",
         "/lib/pkgconfig",
-        "/share/pkgconfig",
-        "/share/aclocal",
-        "/man",
-        "/share/man",
-        "/share/gtk-doc",
-        "*.la",
-        "*.a",
-        "/share/doc",
         "/share/gir-1.0"
     ],
     "modules": [


### PR DESCRIPTION
They are unnecessary because no files are affected by these commands.